### PR TITLE
updated css to improve skills filter look and feel

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -37,7 +37,7 @@ const Checkbox = ({
         >
           <FontAwesomeIcon icon={checkedIcon} color={checkboxColor} />
         </div>
-        <div className="inline-block text-ident">
+        <div className="inline-block">
           {labelText} {checkboxCount != null ? ' (' + checkboxCount + ')' : ''}
         </div>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -155,7 +155,7 @@ ul li {
 .filter-skills li,
 .filter-event li {
   background: none;
-  padding: 0.5rem 0.25rem;
+  padding: .4rem 0rem;
 }
 
 .filter-role-opener {
@@ -832,7 +832,6 @@ label {
   color: #666;
   display: inline-block;
   max-width: 100%;
-  font-weight: bold;
 }
 
 .form-group .field-wrapper {

--- a/src/style.css
+++ b/src/style.css
@@ -578,11 +578,6 @@ pre {
   order: 1;
 }
 
-.text-ident{
-  padding-left: 0.5em;
-  text-indent:-0.5em;
-}
-
 @media screen and (min-width: 600px) {
   .img-large,
   .img-banner img,


### PR DESCRIPTION
This list is too long, and it goes beyond the actual employees' area:
<img width="549" alt="Screen Shot 2020-11-10 at 6 40 57 PM" src="https://user-images.githubusercontent.com/12601228/98758729-55f97880-2384-11eb-946b-b61c90410f6a.png">

I see no reason for having these items in bold either.