### PR TITLE
Fixed padding on profile badges

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -288,9 +288,6 @@ ul li {
 .profile-content p {
   margin-bottom: 15px;
 }
-.profile-content p:first-child {
-  margin-top: 30px;
-}
 .profile-content p:last-child {
   margin-bottom: 30px;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56522256/138178523-d46ff5b0-eb18-4a30-b893-0c7ffe188af4.png)
**Figure: Fixed padding on overlapping profile text**

![image](https://user-images.githubusercontent.com/56522256/138178360-acf29662-490c-4592-9628-043c2c727403.png)
**Figure: Badges were overlapping the profile text**