### PR TITLE
424 style make footer consistent with rules footer

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -35,18 +35,18 @@ const Footer = () => {
       </div>
       <footer className="bg-black py-6 md:py-4 lg:py-2">
         <section className="main-container">
-          <div>
-            <div className="mx-2 md:mx-6 flex flex-col-reverse lg:flex-row justify-between align-middle leading-6">
+          <div className="xl:mx-6">
+            <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
               <div className="py-2">
                 Copyright © {companyShortName} 1990 - {new Date().getFullYear()}
                 . All Rights Reserved.
               </div>
-              <div className="w-full lg:w-3/6 lg:text-right py-2">
+              <div className="w-full md:w-3/6 md:text-right py-2">
                 <a
                   className="footer-link"
                   href="https://github.com/SSWConsulting/SSW.People/issues"
                 >
-                  FEEDBACK TO {companyShortName}
+                  FEEDBACK / SUGGEST A FEATURE
                 </a>
                 <span className="px-2">|</span>
                 <a
@@ -143,7 +143,7 @@ const Footer = () => {
                 . Last deployed {getLastDeployTime()} ago (Build #{' '}
                 {process.env.VERSION_DEPLOYED})
               </div>
-              <div className="lg:text-right py-2">
+              <div className="py-2">
                 <a
                   className="footer-link"
                   href="https://rules.ssw.com.au/rules-to-better-internationalization"

--- a/src/components/skills-list/skills-list.js
+++ b/src/components/skills-list/skills-list.js
@@ -51,7 +51,6 @@ const SkillsList = ({ crmData, skillUrlData }) => {
               </span>
             ))}
           </span>
-          <hr className="Extra-hr" />
           <hr className="print-hidden" />
         </>
       )}

--- a/src/style.css
+++ b/src/style.css
@@ -92,7 +92,8 @@ a.action-btn-link, .favor-list a, .footer-link {
 
 .footer-link  {
   @apply text-gray-300;
-  font-weight: bolder;
+  text-decoration: none;
+  color: rgba(255,255,255);
   transition: all 0.3s ease-in-out;
 }
 
@@ -248,9 +249,7 @@ footer {
 .profile-image-quote {
   margin: 1rem;
 }
-.Extra-hr{
-  visibility: hidden;
-}
+
 .quoteblock {
   font-family: Georgia;
 }
@@ -532,13 +531,7 @@ figure figcaption:before {
 
 .youtube-playlist-arrows{
   position: relative;
-  
 }
-.View-All-Link{
-  float: right;
-  padding-top: 16.8px;
-  padding-right: 20px;
-  }
 
 .arrow-previous{
   float: left;


### PR DESCRIPTION
cc: @adamcogan, @tiagov8

Hi Tiago,

As per our conversation I have restyled the Peoples footer so that it is consistent with the Rules footer. 

![image](https://user-images.githubusercontent.com/97079655/182536465-03740dff-9567-4a22-85cc-bf8a07aadab4.png)
**Figure: current People footer**

![image](https://user-images.githubusercontent.com/97079655/182536681-166510cc-5549-417d-b3f6-c51c0a124915.png)
**Figure: Updated peoples footer**

![image](https://user-images.githubusercontent.com/97079655/182536923-e149b9a7-3bdd-42b2-9196-c7fafb12b21f.png)
**Figure: rules footer**

I could not find an equivalent to https://github.com/SSWConsulting/SSW.Rules/releases/tag/20201117.1 for people so I did not add a link to the build version. 

You will note that in my updated version the build version number has been replaced with "#(VERSION DEPLOYED)" I have not made any changes to cause this so I believe that it is due to my local branch. (I consulted Jack P and he agreed) 