### PR TITLE
💄 CSS - Prevent SVG badges from rendering super large

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -456,6 +456,10 @@ a:hover {
     text-decoration: none !important;
   }
 
+  img {
+    height: 135px;
+  }
+
   p {
     margin: 0 !important;
   }


### PR DESCRIPTION
Before
<img width="1314" alt="CleanShot 2023-07-28 at 15 51 01@2x" src="https://github.com/SSWConsulting/SSW.People/assets/600044/190df1a0-c3ea-43da-8267-477747fd16da">

After
<img width="1254" alt="CleanShot 2023-07-28 at 15 50 49@2x" src="https://github.com/SSWConsulting/SSW.People/assets/600044/e60c52c7-aa4a-4604-86c9-3df6d2b0c9c8">
