### PR TITLE
💄 Make Alumni Status Obvious

### DIFF
--- a/src/components/profile-description/profile-description.js
+++ b/src/components/profile-description/profile-description.js
@@ -18,7 +18,7 @@ const ProfileDescription = ({
         <h1>{personName}</h1>
         {!isActive && (
           <div class="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3">
-            <div class="flex h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
+            <div class="sm:flex hidden h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
               <span class="flex items-center text-sm font-bold text-white">
                 <FontAwesomeIcon
                   icon={faBoxArchive}

--- a/src/components/profile-description/profile-description.js
+++ b/src/components/profile-description/profile-description.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBoxArchive } from '@fortawesome/free-solid-svg-icons';
 
 const ProfileDescription = ({
   personName,
@@ -9,11 +10,27 @@ const ProfileDescription = ({
   location,
   qualifications,
   children,
+  isActive,
 }) => {
   return (
     <div>
       <div className="flex items-center justify-between">
         <h1>{personName}</h1>
+        {!isActive && (
+          <div class="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3">
+            <div class="flex h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
+              <span class="flex items-center text-sm font-bold text-white">
+                <FontAwesomeIcon
+                  icon={faBoxArchive}
+                  className="mr-2"
+                  fontSize={16}
+                />
+                ALUMNI
+              </span>
+            </div>
+          </div>
+        )}
+
         {children}
       </div>
       <h4 className="mb-0">

--- a/src/components/profile-description/profile-description.js
+++ b/src/components/profile-description/profile-description.js
@@ -17,9 +17,9 @@ const ProfileDescription = ({
       <div className="flex items-center justify-between">
         <h1>{personName}</h1>
         {!isActive && (
-          <div class="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3">
-            <div class="sm:flex hidden h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
-              <span class="flex items-center text-sm font-bold text-white">
+          <div className="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3">
+            <div className="sm:flex hidden h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
+              <span className="flex items-center text-sm font-bold text-white">
                 <FontAwesomeIcon
                   icon={faBoxArchive}
                   className="mr-2"
@@ -57,6 +57,7 @@ ProfileDescription.propTypes = {
   location: PropTypes.string,
   qualifications: PropTypes.string,
   children: PropTypes.arrayOf(PropTypes.element),
+  isActive: PropTypes.bool,
 };
 
 export default ProfileDescription;

--- a/src/components/profile-description/profile-description.js
+++ b/src/components/profile-description/profile-description.js
@@ -17,9 +17,9 @@ const ProfileDescription = ({
       <div className="flex items-center justify-between">
         <h1>{personName}</h1>
         {!isActive && (
-          <div className="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3">
-            <div className="sm:flex hidden h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-red px-5 text-xl max-sm:my-5 sm:w-fit">
-              <span className="flex items-center text-sm font-bold text-white">
+          <div className="flex flex-grow flex-wrap gap-2 sm:flex-grow-0 ml-3 scale-75">
+            <div className="flex h-12 w-full shrink-0 items-center justify-center rounded-lg bg-ssw-grey px-5 text-xl max-sm:my-5 sm:w-fit">
+              <span className="flex items-center text-sm font-bold text-ssw-red">
                 <FontAwesomeIcon
                   icon={faBoxArchive}
                   className="mr-2"

--- a/src/templates/person.js
+++ b/src/templates/person.js
@@ -101,6 +101,7 @@ const Person = ({ pageContext }) => {
         jobTitle={jobTitle}
         location={crmData?.location}
         qualifications={frontmatter.qualifications}
+        isActive={isActive}
       >
         <ActionButtons profileId={pageContext.slug}></ActionButtons>
       </ProfileDescription>


### PR DESCRIPTION
Relates to https://github.com/SSWConsulting/SSW.People/issues/309

Added tag+icon next to the title on past employee's profile **(only for screen > 640px）**
![image](https://github.com/SSWConsulting/SSW.People/assets/127192800/07a758df-cdef-45a2-8a55-435bf4a1d83b)
