### PR TITLE
🔍️ SEO - Try fix the google search results for the GitHub repo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 <img src="https://github.com/SSWConsulting/SSW.People/raw/main/_wiki/images/ssw-banner.png">
 
-# SSW.People
+# SSW People
 
 v2 of the EmployeePages. No more SharePoint, idea is to prove the implementation for Rules v2
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,11 @@
 
 # SSW People
 
-v2 of the EmployeePages. No more SharePoint, idea is to prove the implementation for Rules v2
+This is a Gatsby generated website, leveraging data from SSW.People.Profiles (GitHub) and SSW CRM. Pages are automatically re-generated and published to our SSW website when a profile markdown page is updated. 
+
+Learn more on [Adam's Blog - Introducing SSW People!](https://adamcogan.com/2020/02/10/introducing-ssw-people)
+
+**SSW People** is the **SSW Employee Pages V2** - No more SharePoint!
 
 This is a Gatsby generated site pulling data from:
 
@@ -22,8 +26,6 @@ This is a Gatsby generated site pulling data from:
   
   ![Desktop Development with C++ workload](https://user-images.githubusercontent.com/38869720/183000582-463e2fb8-7c8f-4636-81fb-5bdb95758d78.png)
   **Figure: Desktop Development with C++ workload**
-
-
 
 ### Getting ready for development
 


### PR DESCRIPTION
I noticed this repo looks bad on Google search.

I am guessing Google looked at the H1 (SSW.People) and didn't like that it didn't look like readable words.

<img width="1800" alt="image" src="https://github.com/SSWConsulting/SSW.People/assets/38869720/52a9012e-512e-4d1a-ad69-ed4abcd55882">

**Figure: Ugly search result**