### PR TITLE
✨ Filter Out Skills Without Consulting Pages

### DIFF
--- a/src/helpers/CRMApi.js
+++ b/src/helpers/CRMApi.js
@@ -82,8 +82,8 @@ const getUsersSkills = async () => {
       };
 
       return userSkill;
-    });
-  // .filter((us) => us.published === 'Published');
+    })
+    .filter((us) => us.published === 'Published');
 
   return usersSkills;
 };


### PR DESCRIPTION
Relates to https://github.com/SSWConsulting/SSW.People/issues/373#issuecomment-1958500417

In this PR:
- Reimplement the filter feature for People to only show skills with consulting pages

![image](https://github.com/SSWConsulting/SSW.People/assets/127192800/bc79beae-373e-41a8-9736-59f1c79fdef8)
