### PR TITLE
🔥 Hotfix - megamenu underline on mobile layouts

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -342,6 +342,11 @@ ul.favor-list li {
   background: url(./images/linkedin.png) 0 center no-repeat;
 }
 
+
+header > div > div > a /*TODO: Fix this at the source https://github.com/SSWConsulting/SSW.MegaMenu/issues/101*/
+{
+  text-decoration: none; 
+}
 .skype {
   background: url(./images/skype.png) 0 center no-repeat;
 }


### PR DESCRIPTION
### Description

There's an underline in the Megamenu on live site so I've created a PR for fixing it.

- Fixed: #659 

### Screenshot

![image](https://github.com/user-attachments/assets/f6938ea2-98c8-43d6-a49c-240ad2ee1cd5)
