### PR TITLE
Increased z-index value of megamenu

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -435,6 +435,10 @@ div.megamenu a {
   text-decoration: none;
 }
 
+div.megamenu {
+  z-index: 20;
+}
+
 /** Custom blocks images handling **/
 
 .img-badge {


### PR DESCRIPTION
Fixes #701 

Increased `z-index` value of megamenu on SSW People, because it's value was same with profile photo button. That's buttons were showing

![image](https://github.com/user-attachments/assets/949aac82-79e9-462c-97f0-0da0a187e6bc)
**Figure: Profile photo buttons are not showing when menu is open**