### PR TITLE
#632 - Added alphabetical sort to skills side bar

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -98,6 +98,7 @@ const Index = ({ data }) => {
   const filterAndSortSkills = (skills, skillsInUse, skillCount) => {
     return skills
       .filter((s) => skillsInUse.has(s.service.service))
+      .sort((a, b) => a.service.service.localeCompare(b.service.service)) // Alphabetical sort
       .sort((a, b) => {
         const hasHighlightA = a.service.highlightskill ? 1 : 0;
         const hasHighlightB = b.service.highlightskill ? 1 : 0;


### PR DESCRIPTION
This PR adds an alphabetical sort before the additional sorting to make it easier to find skills https://github.com/SSWConsulting/SSW.People/issues/632

Current sorting in SSW.People | Skills side bar
![image](https://github.com/user-attachments/assets/c9733640-d3f4-4cbb-8b68-c4cf27a5e9a1)

This PR sorts these alphabetically instead
![image](https://github.com/user-attachments/assets/05bb4c0a-31b8-49c2-92dd-15e730c396bf)
