### PR TITLE
735 - Add CSS styling to fix the z-index of the megamenu

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -439,6 +439,11 @@ div.megamenu {
   z-index: 20;
 }
 
+/* Ensure ssw.megamenu appears above all other elements */
+div[id^="headlessui-dialog-panel"] {
+  z-index: 50;
+}
+
 /** Custom blocks images handling **/
 
 .img-badge {


### PR DESCRIPTION
Fixes https://github.com/SSWConsulting/SSW.People/issues/735

Now functions the same as https://www.ssw.com.au/

![image](https://github.com/user-attachments/assets/f3062ccf-76f8-4427-9ff4-021ec25078ce)
**Mobile view with hamburger menu**

![image](https://github.com/user-attachments/assets/80e3d425-3afb-4414-9ef3-5b4f6a3ee6db)
**Menu opens and appears above everything**
