### PR TITLE
Fixed CSS for custom image block sizes

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1280,6 +1280,24 @@ font-size: 0.8rem;
   transition: all 0.2s ease-in-out;
 }
 
+.custom-block.img-large .gatsby-resp-image-wrapper {
+  max-width: 600px !important;
+  width: 100% !important;
+  height: auto !important;
+}
+
+.custom-block.img-medium .gatsby-resp-image-wrapper {
+  max-width: 400px !important;
+  width: 100% !important;
+  height: auto !important;
+}
+
+.custom-block.img-small .gatsby-resp-image-wrapper {
+  max-width: 200px !important;
+  width: 100% !important;
+  height: auto !important;
+}
+
 /**
 * This injects Tailwind's component classes and any component classes
 * registered by plugins.


### PR DESCRIPTION
Fixes the custom image blocks not adhering to the size constraints
https://www.ssw.com.au/people/bob-northwind/

**Before Change**
![image](https://github.com/user-attachments/assets/437ce08c-80af-4152-a61f-1db2838b9748)

**After Fix**
![image](https://github.com/user-attachments/assets/ecdfeaef-d948-43bd-87e4-ce968071d080)
