### PR TITLE
Add author filtering and CORS proxy for latest rules

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -638,8 +638,23 @@ exports.onCreateDevServer = ({ app }) => {
       res.set('Cache-Control', 'no-store');
       res.set('X-SSW-People-Proxy', 'axios');
 
-      upstream.data.pipe(res);
-    } catch (e) {
+      const upstreamStream = upstream.data;
+      const abortUpstream = () => {
+        if (upstreamStream && !upstreamStream.destroyed) upstreamStream.destroy();
+      };
+
+      upstreamStream.on('error', () => {
+        if (!res.headersSent) res.status(502);
+        if (!res.writableEnded && !res.destroyed) res.end();
+      });
+
+      req.on('aborted', abortUpstream);
+      res.on('close', () => {
+        if (!res.writableEnded) abortUpstream();
+      });
+
+      upstreamStream.pipe(res);
+    } catch {
       res.status(500).json({ error: 'Failed to proxy rules JSON' });
     }
   });

--- a/src/components/rules-widget/rules-widget.js
+++ b/src/components/rules-widget/rules-widget.js
@@ -22,9 +22,7 @@ function normalizeAuthor(author) {
         const u = new URL(raw);
         const last = u.pathname.split("/").filter(Boolean).pop();
         return (last || "").trim();
-    } catch (e) {
-        // not a URL
-    }
+    } catch { }
 
     return raw
         .replace(/^@/, "")
@@ -95,7 +93,7 @@ export default function RulesWidget({
                     setItems(filtered);
                     setStatus("success");
                 }
-            } catch (e) {
+            } catch {
                 if (!cancelled) {
                     setItems([]);
                     setStatus("error");


### PR DESCRIPTION
This pull request enhances the `RulesWidget` component to improve how it fetches and displays the latest rules for a given author.

**Development environment improvements:**

* Added an `onCreateDevServer` handler in `gatsby-node.js` to proxy requests for `people-latest-rules.json` during development, avoiding CORS issues by streaming the file from the production server.
* Added the `axios` dependency to support HTTP requests in the dev server proxy.

**RulesWidget data handling and robustness:**

* Refactored `RulesWidget` to fetch rule data from the new `people-latest-rules.json` endpoint, using the dev proxy path in development and the production URL otherwise.
* Introduced `normalizeAuthor` and `pickRulesForAuthor` helper functions to standardize author identifiers and reliably extract rules for the correct user from the JSON data, handling various input formats.
* Updated the widget to filter, sort, and limit the displayed rules per author, and to consistently use the normalized author for all lookups and links. [[1]](diffhunk://#diff-48e63ecd9739c6b80a61b9cd084a5bc8d4dc343babbb4fba6820f24eed4ee36dL22-R96) [[2]](diffhunk://#diff-48e63ecd9739c6b80a61b9cd084a5bc8d4dc343babbb4fba6820f24eed4ee36dL52-R111)

<img width="2477" height="1550" alt="image" src="https://github.com/user-attachments/assets/108f633d-b08f-4984-a826-57e9afafe442" />
