### PR TITLE
Fix CRM skill truncation on profile pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+Package manager is **yarn 4** (Berry). Node 20 LTS.
+
+- `yarn dev` — Gatsby develop server (requires `.env.development`)
+- `yarn build` — generates favicons, then `gatsby build --prefix-paths --log-pages` (requires `.env.production`)
+- `yarn devbuild` — same as build, without prefix paths / page log
+- `yarn serve` / `yarn ssr` — serve a built site (`ssr` = build then serve)
+- `yarn lint` — eslint with `--max-warnings=0`
+- `yarn test` — runs `ava **/*.test.js --verbose` (currently only `scripts/lighthouse.test.js`)
+- `yarn format` — prettier on `src/**/*.js`
+
+`.env.development` and `.env.production` are required for `dev` and `build` respectively. Variables are listed in `.env.template`; values are stored in the SSW Keeper record.
+
+## Architecture
+
+This is a **Gatsby 5** site that generates one page per SSW employee by merging three data sources at build time:
+
+1. **Markdown profiles** sourced via `gatsby-source-git` from [SSW.People.Profiles](https://github.com/SSWConsulting/SSW.People.Profiles) (`*-*/**` and `badges/**` patterns). The `frontmatter.id` is the join key.
+2. **Dynamics CRM** — `src/helpers/CRMApi.js` calls Microsoft Dataverse with an OAuth client-credentials flow (`CRM_*` env vars) for employees, sites, and skills. `SampleProfileCRMData.json` is appended for the sample profile.
+3. **YouTube Data API** — playlist items per user (`YOUTUBE_API_KEY`).
+
+Page generation lives entirely in `gatsby-node.js`:
+
+- `sourceNodes` fetches the SSW megamenu, CRM data, skills, and YouTube playlists, then creates `CrmDataCollection`, `SkillUrls`, `MegaMenuGroup`, and `PeopleYoutubePlaylists` nodes.
+- `createPages` joins markdown profiles to CRM rows by `frontmatter.id`, routes active employees to `/<slug>` and inactive ones to `/alumni/<slug>` (alumni prefix from `site-config.js`), creates redirects from nicknames, and writes a sanitised `profile.md` per person plus `public/people.json` (used downstream).
+- The single page template is `src/templates/person.js`. There is no per-person source file.
+
+`site-config.js` holds non-secret site metadata (path prefix, locations/role ordering, profiles repo URL).
+
+### China build
+
+When `CHINA_BUILD=TRUE`, `pathPrefix` is suffixed with `-cn` and `chinaHelper.cleanHtml` strips blocked third-party resources from rendered profile HTML. Most code paths branch on `chinaHelper.isChinaBuild`.
+
+### Webpack quirks
+
+`gatsby-node.js#onCreateWebpackConfig` adds Node polyfills (`stream-browserify`, `buffer`, `util`, etc.), aliases `path` to `path-browserify`, and uses `directory-named-webpack-plugin` so that `import Foo from 'components/foo'` resolves to `components/foo/foo.js`. `react-lazy-youtube` is null-loaded during `build-html` because it touches `window`.
+
+### Dev-only rules proxy
+
+`onCreateDevServer` exposes `/__rules/people-latest-rules.json` proxying `https://www.ssw.com.au/rules/people-latest-rules.json` to avoid browser CORS in dev. The `RulesWidget` component fetches this URL.
+
+### Pinned dependencies (do not bump blindly)
+
+See `packageComments` in `package.json`:
+- `gatsby-remark-custom-blocks` ^3.2.0 — locked for compatibility with `gatsby-transformer-remark` ^3.2.0
+- `gatsby-transformer-remark` ^3.2.0 — locked because of the above
+- `favicons` 6.2.2 — see jantimon/favicons-webpack-plugin#309
+- `gatsby-remark-relative-images` ^0.3.0 — newer versions break image handling
+- `sharp` resolution pinned to `0.33.2`
+
+## Conventions
+
+- Single quotes, prettier-enforced (`'prettier/prettier': 'warn'`, `quotes: ['warn', 'single']`).
+- Lint is zero-warnings: `eslint --max-warnings=0`. `no-console` is `warn`, so any new `console.*` call will fail CI unless wrapped in `eslint-disable`.
+- `prop-types` is `warn` — keep PropTypes on new components.
+- Branching: branch off `main` per the Readme; `release/xx` is the production branch and merges to `main` deploy to staging.

--- a/src/helpers/CRMApi.js
+++ b/src/helpers/CRMApi.js
@@ -11,6 +11,26 @@ const SCOPE = process.env.CRM_SCOPE;
 
 const crmUrl = `https://${TENANT}/api/data/v9.1`;
 
+// Dataverse caps each OData response at 5000 rows and returns an
+// @odata.nextLink for the rest. Follow the link until exhausted so we
+// don't silently drop data once a collection grows past one page.
+const fetchAllPages = async (url) => {
+  let all = [];
+  let next = url;
+  let pages = 0;
+  while (next) {
+    const res = await axios.get(next);
+    all = all.concat(res.data.value);
+    next = res.data['@odata.nextLink'];
+    pages++;
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    `Fetched ${all.length} rows from ${url.split('?')[0]} across ${pages} page(s)`
+  );
+  return all;
+};
+
 const getViewDataFromCRM = async () => {
   const accessToken = await getToken();
 
@@ -45,14 +65,14 @@ const getSites = async () => {
 };
 
 const getUsersSkills = async () => {
-  const skillsRes = await axios.get(`${crmUrl}/ssw_skills`);
-  const skills = skillsRes.data.value;
+  const skills = await fetchAllPages(`${crmUrl}/ssw_skills`);
 
   // Used to link skills to their marketing page urls
   const consultingPages = {};
 
-  const consultingReq = await axios.get(`${crmUrl}/ssw_consultingservices`);
-  const consultingData = consultingReq.data.value;
+  const consultingData = await fetchAllPages(
+    `${crmUrl}/ssw_consultingservices`
+  );
   Object.keys(consultingData).map((page) => {
     const pageName = consultingData[page].ssw_name;
     const pageUrl = consultingData[page].ssw_webpageurl;
@@ -60,8 +80,8 @@ const getUsersSkills = async () => {
     consultingPages[pageName] = pageUrl;
   });
 
-  const usersSkillsReq = await axios.get(`${crmUrl}/ssw_userskills`);
-  const usersSkills = usersSkillsReq.data.value
+  const usersSkillsRaw = await fetchAllPages(`${crmUrl}/ssw_userskills`);
+  const usersSkills = usersSkillsRaw
     .filter((us) => us.statecode !== 1)
     .map((us) => {
       const skill = skills.find((s) => s.ssw_skillid === us._ssw_skillid_value);
@@ -120,13 +140,8 @@ const getEmployees = async (sites, usersSkills, current) => {
   const queryFilter = `?savedQuery=${viewId}`;
   const userQuery = `${crmUrl}/systemusers${queryFilter}`;
 
-  const response = await axios.get(userQuery);
-  const employees = convertToSimpleFormat(
-    response.data.value,
-    sites,
-    usersSkills,
-    current
-  );
+  const users = await fetchAllPages(userQuery);
+  const employees = convertToSimpleFormat(users, sites, usersSkills, current);
 
   return employees;
 };


### PR DESCRIPTION
## Summary
- Dataverse OData responses are capped at 5000 rows; `src/helpers/CRMApi.js` ignored `@odata.nextLink`, silently truncating `/ssw_userskills`, `/ssw_skills`, `/ssw_consultingservices`, and the saved-query systemusers view.
- Marina Gerber's profile (and likely others) was showing only a couple of skills because most user-skill rows fell on a later page, and many that were returned were filtered out when their matching skill row hadn't been fetched.
- Adds a `fetchAllPages` helper that loops on `@odata.nextLink` and uses it for the four unbounded collections. `/sites` left as-is.

Fixes #835

## Test plan
- [x] Build locally with real CRM creds (`yarn build`) and confirm console shows `Fetched N rows from .../ssw_userskills across M page(s)` with `N > 5000` and `M > 1`
- [x] Load Marina Gerber's profile and confirm TinaCMS plus other Published skills render
- [x] Spot-check 2-3 other profiles for previously-missing skills
- [ ] Staging deploy from this PR's merge to `main` — verify the same on staging before promoting to `release/xx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)